### PR TITLE
feat: 채팅 상대방 프로필 사진 표시 구현

### DIFF
--- a/MeloMeter/Data/Repositories/ChatRepository.swift
+++ b/MeloMeter/Data/Repositories/ChatRepository.swift
@@ -72,14 +72,10 @@ class ChatRepository: ChatRepositoryP{
                         return date1.seconds > date2.seconds ||
                         (date1.seconds == date2.seconds && date1.nanoseconds > date2.nanoseconds)
                     }
-                    // 최대 30개의 매세지를 가져온다
                     let numberOfMessagesToRetrieve = 1
                     let recentChatFields = Array(sortedChatFields.suffix(numberOfMessagesToRetrieve))
-                    
-                    // DTO타입으로 형변환
                     self.recieveChatMessage.accept(self.convertToChatDTOArray(from: recentChatFields))
                 } else {
-                    //비어있는경우
                     self.recieveChatMessage.accept([])
                 }
             }) { error in

--- a/MeloMeter/Presenter/TabBar/Chat/ChatVC.swift
+++ b/MeloMeter/Presenter/TabBar/Chat/ChatVC.swift
@@ -94,6 +94,7 @@ class ChatVC: MessagesViewController, MessagesDataSource {
         super.viewDidAppear(animated)
         DispatchQueue.main.async {
             if !self.messageList.isEmpty {
+                self.messagesCollectionView.reloadDataAndKeepOffset()
                 self.messagesCollectionView.scrollToItem(at: IndexPath(row: 0, section: self.messageList.count-1), at: .centeredVertically, animated: false)
             }
         }
@@ -194,7 +195,6 @@ class ChatVC: MessagesViewController, MessagesDataSource {
     //인풋바 아이탬 설정
     private func configureInputBarItems() {
         messageInputBar.setRightStackViewWidthConstant(to: 56, animated: false)
-        
         messageInputBar.sendButton.backgroundColor = .gray5
         messageInputBar.sendButton.setSize(CGSize(width: 44, height: 44), animated: false)
         messageInputBar.sendButton.title = "전송"
@@ -242,12 +242,8 @@ class ChatVC: MessagesViewController, MessagesDataSource {
     
     // MARK: - Binding
     func setBindings() {        
-        //바인딩
         let input = ChatVM.Input(
             viewDidLoadEvent: self.viewDidLoadEvent
-                .map({ _ in })
-                .asObservable(),
-            viewWillApearEvent: self.rx.methodInvoked(#selector(viewWillAppear(_:)))
                 .map({ _ in })
                 .asObservable(),
             backBtnTapEvent: self.backBarButton.rx.tap
@@ -260,7 +256,7 @@ class ChatVC: MessagesViewController, MessagesDataSource {
         )
         
         guard let output = self.viewModel?.transform(input: input, disposeBag: self.disposeBag) else{ return }
-        
+          
         output.senddSuccess
             .bind(onNext: {result in
                 if result {

--- a/MeloMeter/Presenter/TabBar/Chat/ChatVM.swift
+++ b/MeloMeter/Presenter/TabBar/Chat/ChatVM.swift
@@ -15,34 +15,32 @@ class ChatVM {
     private var chatUseCase: ChatUseCase
     
     struct Input {
-        //전달받을 변수
         let viewDidLoadEvent: Observable<Void>
-        let viewWillApearEvent: Observable<Void>
         let backBtnTapEvent: Observable<Void>
         let mySendTextMessage: Observable<MockMessage>
         let mySendImageMessage: Observable<MockMessage>
     }
     
     struct Output {
-        //전달할 변수
         var senddSuccess = PublishSubject<Bool>()
         var getMessage = PublishSubject<[MockMessage]>()
         var getRealTimeMessage = PublishSubject<[MockMessage]>()
     }
     
     
-    struct NoticeInput {
+    struct DisplayInput {
+        let viewWillApearEvent: Observable<Void>
         let lastAnswerBtnTapEvent: Observable<Void>
         let goAnswerBtnTapEvent: Observable<Void>
     }
     
-    struct NoticeOutput {
+    struct DisplayOutput {
         var questionNumber = PublishSubject<String>()
         var questionText = PublishSubject<String>()
+        var otherProfileImage = PublishSubject<UIImage>()
     }
     
     // MARK: Input
-    // 데이트 타입을 받아서, 우리가 원하는(멜로망스)에 맞는 형태로 바꾸는 메서드를 Date유틸에 추가하고, 이 동작을 하는 메서드를 만들어야해 여기에.
     init(coordinator: ChatCoordinator, chatUseCase: ChatUseCase) {
         self.coordinator = coordinator
         self.chatUseCase = chatUseCase
@@ -86,7 +84,6 @@ class ChatVM {
         
         self.chatUseCase.recieveChatMessageService
             .subscribe(onNext: {chatMessageList in
-                print(chatMessageList, "*****************")
                 output.getMessage.onNext(chatMessageList ?? [])
             })
             .disposed(by: disposeBag)
@@ -106,22 +103,20 @@ class ChatVM {
         return output
     }
     
-    func noticeTransform(input: NoticeInput, disposeBag: DisposeBag) -> NoticeOutput {
-        let output = NoticeOutput()
-//        input.viewDidLoadEvent
-//            .subscribe(onNext: { [weak self] _ in
-//                guard let self = self else{ return }
-//                self.chatUseCase.getChatMessageService()
-//                self.chatUseCase.startRealTimeChatMassage()
-//            })
-//            .disposed(by: disposeBag)
-//
-//        input.viewWillApearEvent
-//            .subscribe(onNext: { [weak self] _ in
-//                guard let self = self else{ return }
-//
-//            })
-//            .disposed(by: disposeBag)
+    func noticeTransform(input: DisplayInput, disposeBag: DisposeBag) -> DisplayOutput {
+        let output = DisplayOutput()
+
+        input.viewWillApearEvent
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else{ return }
+                self.chatUseCase.getProfileImage()
+                    .subscribe(onSuccess: { image in
+                        output.otherProfileImage.onNext(image)
+                    })
+                    .disposed(by: disposeBag)
+            })
+            .disposed(by: disposeBag)
+        
         input.lastAnswerBtnTapEvent
             .subscribe(onNext: {[weak self] _ in
                 self?.coordinator?.showHundredQAFlow()

--- a/MeloMeter/Presenter/TabBar/Chat/Coordinator/ChatCoordinator.swift
+++ b/MeloMeter/Presenter/TabBar/Chat/Coordinator/ChatCoordinator.swift
@@ -27,7 +27,11 @@ extension ChatCoordinator {
     func showChatVC() {
         let firebaseService = DefaultFirebaseService()
         let viewController = DisplayChatVC(
-            viewModel: ChatVM(coordinator: self, chatUseCase: ChatUseCase(chatRepository: ChatRepository(firebaseService: firebaseService), coupleRepository: CoupleRepository(firebaseService: firebaseService))
+            viewModel: ChatVM(coordinator: self,
+                              chatUseCase: ChatUseCase(
+                                chatRepository: ChatRepository(firebaseService: firebaseService),
+                                coupleRepository: CoupleRepository(firebaseService: firebaseService),
+                                userRepository: UserRepository(firebaseService: firebaseService))
                              )
         )
         viewController.hidesBottomBarWhenPushed = true

--- a/MeloMeter/Presenter/TabBar/Chat/MessageKit/CameraInputBarAccessoryView.swift
+++ b/MeloMeter/Presenter/TabBar/Chat/MessageKit/CameraInputBarAccessoryView.swift
@@ -37,7 +37,6 @@ class CameraInputBarAccessoryView: InputBarAccessoryView {
     lazy var attachmentManager: AttachmentManager = { [unowned self] in
         let manager = AttachmentManager()
         manager.delegate = self
-        
         return manager
     }()
     
@@ -155,7 +154,7 @@ extension CameraInputBarAccessoryView: UIImagePickerControllerDelegate, UINaviga
 extension CameraInputBarAccessoryView: AttachmentManagerDelegate {
     // MARK: - AttachmentManagerDelegate
     
-    func attachmentManager(_: AttachmentManager, shouldBecomeVisible: Bool) {
+    func attachmentManager(_ manager: AttachmentManager, shouldBecomeVisible: Bool) {
         setAttachmentManager(active: shouldBecomeVisible)
     }
     
@@ -163,7 +162,10 @@ extension CameraInputBarAccessoryView: AttachmentManagerDelegate {
         sendButton.isEnabled = manager.attachments.count > 0
     }
     
-    func attachmentManager(_ manager: AttachmentManager, didInsert _: AttachmentManager.Attachment, at _: Int) {
+    func attachmentManager(_ manager: AttachmentManager, didInsert cell: AttachmentManager.Attachment, at index: Int) {
+        manager.dataSource?.attachmentManager(manager, cellFor: cell, at: index)
+            .deleteButton.setImage(UIImage(named: "cancel"), for: .normal)
+
         sendButton.isEnabled = manager.attachments.count > 0
     }
     

--- a/MeloMeter/Presenter/TabBar/MyProfile/MyProfile/MyProfileVM.swift
+++ b/MeloMeter/Presenter/TabBar/MyProfile/MyProfile/MyProfileVM.swift
@@ -53,7 +53,6 @@ class MyProfileVM {
                             })
                             .disposed(by: disposeBag)
                         guard let name = user.name, let phoneNumber = user.phoneNumber, let otherUid = user.otherUid else{ return }
-                        print("내 정보", user.name, user.otherUid)
                         self.myProfileUseCase.getDdayInfo(otherUid: otherUid)
                             .subscribe(onSuccess: { dDayInfo in
                                 output.coupleUserName.accept("\(name) & \(dDayInfo[0])")
@@ -97,7 +96,6 @@ class MyProfileVM {
         input.editProfileBtnTapEvent
             .subscribe(onNext: {[weak self] _ in
                 guard let self = self else{ return }
-                print("프로필 탭이벤트")
                 self.coordinator?.showEditProfileVC()
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
- ChatUseCase에 UserRepository와의 의존 관계 생성
- UserRepository에 getUserInfo() 메서드를 통해 상대방 정보를 호출 후 스토리지에서 프로필 사진을 가져옵니다. ChatRepository -> Single<UIImage?> ->  ChatUseCase -> Single<UIImage> -> ChatVM -> DisplayChatVC => Avatar() 객체로 MessagesDisplayDelegate 메서드를 통해 프로필 사진을 삽입해줍니다.