### PR TITLE
feat: 카카오톡 공유 메세지로 진입 시 초대코드 복사 기능 구현

### DIFF
--- a/MeloMeter/App/SceneDelegate.swift
+++ b/MeloMeter/App/SceneDelegate.swift
@@ -28,8 +28,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let url = URLContexts.first?.url else { return }
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
             let queryItems = components.queryItems ?? []
+            
             for queryItem in queryItems {
-                if queryItem.name == "appBtnTapped", let otherCode = queryItem.value {
+                if queryItem.name == "inviteCode", let otherCode = queryItem.value {
+                    let otherInviteCode = otherCode.components(separatedBy: " ")
                     UserDefaults.standard.set(otherCode, forKey: "otherInviteCode")
                     appCoordinator?.start()
                 }


### PR DESCRIPTION
- 카카오 API를 JSON 형태 템플릿 전송 => 카카오 개발자 웹 템플릿으로 변경
- 기타: 메세지 템플릿에 상세 설명도 추가해봤습니다!